### PR TITLE
Adds the BiconLogo icon to list of icon exports

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -201,6 +201,12 @@ Object.defineProperty(exports, "BiconLink", {
     return _BiconLink["default"];
   }
 });
+Object.defineProperty(exports, "BiconLogo", {
+  enumerable: true,
+  get: function get() {
+    return _BiconLogo["default"];
+  }
+});
 Object.defineProperty(exports, "BiconMain", {
   enumerable: true,
   get: function get() {
@@ -379,6 +385,7 @@ var _BiconImage = _interopRequireDefault(require("./BiconImage"));
 var _BiconImageSmall = _interopRequireDefault(require("./BiconImageSmall"));
 var _BiconLeft = _interopRequireDefault(require("./BiconLeft"));
 var _BiconLink = _interopRequireDefault(require("./BiconLink"));
+var _BiconLogo = _interopRequireDefault(require("./BiconLogo"));
 var _BiconMain = _interopRequireDefault(require("./BiconMain"));
 var _BiconMin = _interopRequireDefault(require("./BiconMin"));
 var _BiconMobile = _interopRequireDefault(require("./BiconMobile"));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,12 @@
 {
   "name": "blockbite-icons",
-  "version": "4.1.0",
+  "version": "4.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "blockbite-icons",
-      "version": "4.1.0",
-      "dependencies": {
-        "typescript": "^5.4.3"
-      },
+      "version": "4.1.2",
       "devDependencies": {
         "@babel/cli": "^7.0.0",
         "@babel/core": "^7.0.0",
@@ -2784,18 +2781,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
-      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -4824,11 +4809,6 @@
       "requires": {
         "is-number": "^7.0.0"
       }
-    },
-    "typescript": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
-      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockbite-icons",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,4 @@
 declare module 'blockbite-icons' {
-  export function .DS_Store(): JSX.Element;
   export function Accessibility(): JSX.Element;
   export function ActivityLog(): JSX.Element;
   export function AlignBaseline(): JSX.Element;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1256,11 +1256,6 @@
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
-"fsevents@~2.3.2":
-  "integrity" "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  "version" "2.3.3"
-
 "function-bind@^1.1.2":
   "integrity" "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
   "resolved" "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -1577,11 +1572,6 @@
   "version" "5.0.1"
   dependencies:
     "is-number" "^7.0.0"
-
-"typescript@^5.4.3":
-  "integrity" "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg=="
-  "resolved" "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz"
-  "version" "5.4.3"
 
 "unicode-canonical-property-names-ecmascript@^2.0.0":
   "integrity" "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ=="


### PR DESCRIPTION
**Issue**
Resolves #7 

**Background**
An error occurs when trying to use the Blockbite Logo icon (BiconLogo) from a project using the `blockbite-icons` package.

**Changes**
- Adds an export for the BiconLogo component within `dist/index.js`
- Increments version
- Removes `.DS_Store` from type definition
- Updates lockfiles

**Screencast**

https://github.com/merijnponzo/blockbite-icons/assets/1920921/2ad296ef-5fb5-44c6-8922-d9c98b00bb1c


