### PR TITLE
Declaration file is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "blockbite-icons",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "main": "dist/index.js",
+  "types": "types/index.d.ts",
   "module": "dist/index.js",
   "scripts": {
     "build": "babel jsx --out-dir dist",


### PR DESCRIPTION
**Issue**
Resolves #9 

**Background**
Previously, the following error would trigger when importing a Blockbite icon from within a TypeScript file:

```
Could not find a declaration file for module 'blockbite-icons'. '/Users/merijnverve/Documents/buroponzo/_blockbite/blockbite-dev/node_modules/blockbite-icons/dist/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/blockbite-icons` if it exists or add a new declaration (.d.ts) file containing `declare module 'blockbite-icons';`ts(7016)
```

![image](https://github.com/merijnponzo/blockbite-icons/assets/1920921/e2c755ff-808b-461b-be2b-fdc6730abc52)


**Change**
We need to inform the consumer of the package where the definitions file is, and we can do that via a `types` field within `package.json`

**Testing Steps**
- Pull these changes
- Replace the `node_modules/blockbite-icons` directory where you are using Blockbite Icons with these new changes
- Import one of the icons exported by `dist/index.js`


https://github.com/merijnponzo/blockbite-icons/assets/1920921/6e843f1a-40df-4bdb-9b40-eb1b48284f60

